### PR TITLE
feat(TypeCheckboxesFilter): Show checkoxes before the search and target audience

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -21,7 +21,7 @@ interface ButtonType {
 const getSizeClasses = (size: ButtonType['size']): string => {
   switch (size) {
     case 'large':
-      return 'text-2xl py-3 px-5 rounded gap-x-5'
+      return 'text-xl xs:text-2xl py-3 px-5 rounded gap-x-5'
     case 'small':
       return 'text-base py-2 px-3 rounded gap-x-2'
     case 'extrasmall':

--- a/src/components/FiltersList.tsx
+++ b/src/components/FiltersList.tsx
@@ -22,6 +22,7 @@ import { useActiveIdsBySearchTerm } from '@lib/hooks/useActiveIdsBySearchTerm'
 import { Spinner } from './icons/Spinner'
 import { useRouter } from 'next/router'
 import { useIsMobile } from '@lib/hooks/useIsMobile'
+import TypeCheckboxesFilter from './TypeCheckboxesFilter'
 
 export const FiltersList: FC<{
   recordsWithOnlyLabels: RecordsWithOnlyLabelsType[]
@@ -118,6 +119,24 @@ export const FiltersList: FC<{
           </button>
         )}
       </div>
+      <p className="text-lg mb-6">{texts.offerTypesIntroText}</p>
+      <div className="flex gap-8 flex-wrap text-lg mb-6">
+        <TypeCheckboxesFilter
+          onChange={({ text, categories }) =>
+            updateUrlState({
+              ...urlState,
+              q: text,
+              qCategories:
+                stateSearchCategoriesToUrlSearchCategories(categories),
+            })
+          }
+          text={urlState.q || ''}
+          categories={urlSearchCategoriesToStateSearchCategories(
+            urlState.qCategories
+          )}
+          disabled={fieldsDisabled}
+        />
+      </div>
       <p className="text-lg mb-6">{texts.optionalFurtherSearchIntroText}</p>
       <div className="flex gap-8 flex-wrap text-lg mb-6">
         <TextSearch
@@ -186,7 +205,6 @@ export const FiltersList: FC<{
                   break
               }
             }}
-            className="mb-12"
           />
         </div>
       </div>

--- a/src/components/SwitchButton.tsx
+++ b/src/components/SwitchButton.tsx
@@ -21,16 +21,16 @@ export const SwitchButton: FC<SwitchButtonPropsType> = ({
     onClick={() => !disabled && onToggle(!value)}
     className={classNames(
       className,
-      `mb-8 flex w-max gap-5 text-lg items-center`,
+      `mb-8 flex w-max max-w-full gap-4 xs:gap-5 text-lg items-center`,
       `transition-colors relative text-left`,
-      `focus:outline-none group`,
+      `focus:outline-none group leading-5`,
       !disabled && `hover:text-primary`,
       disabled && `cursor-not-allowed text-gray-40`
     )}
   >
     <span
       className={classNames(
-        `rounded-full p-1 flex relative w-[61px] transition-colors`,
+        `rounded-full p-1 flex relative w-[61px] transition-colors shrink-0`,
         !disabled && [
           `border `,
           `group-focus:outline-none group-focus:ring-2 group-focus:ring-primary`,
@@ -55,7 +55,7 @@ export const SwitchButton: FC<SwitchButtonPropsType> = ({
         )}
       />
     </span>
-    {children}
+    <span>{children}</span>
     {tooltip && (
       <span
         className={classNames(

--- a/src/components/TextSearch.tsx
+++ b/src/components/TextSearch.tsx
@@ -1,35 +1,17 @@
 import { TextsMapType, useTexts } from '@lib/TextsContext'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import TextInput from './TextInput'
-import Checkbox from './Checkbox'
 import classNames from '@lib/classNames'
 import { Check } from './icons/Check'
 import { Cross } from './icons/Cross'
-import FacilityType from './FacilityType'
-import {
-  facilityTypeToKeyMap,
-  getKeyByFacilityType,
-} from '@lib/facilityTypeUtil'
-import { MinimalRecordType } from '@lib/mapRecordToMinimum'
-
-type CategoriesType = Partial<{
-  categorySelfHelp: boolean
-  categoryAdvising: boolean
-  categoryClinics: boolean
-  categoryOnlineOffers: boolean
-  categoryDistrictOfficeHelp: boolean
-}>
-interface StateType {
-  text: string
-  categories: CategoriesType
-}
+import { StateType } from './TypeCheckboxesFilter'
 
 interface TextSearchProps extends StateType {
   onChange: (state: Partial<StateType>) => void
   disabled?: boolean
 }
 
-type CategoriesTextMapType = Record<keyof CategoriesType, string>
+type CategoriesTextMapType = Record<keyof StateType['categories'], string>
 
 function TextSearch({
   text: initialText,
@@ -60,16 +42,6 @@ function TextSearch({
   useEffect(() => {
     setText(initialText || '')
   }, [initialText])
-
-  const checkboxes = useMemo(() => {
-    const facilityTypeKeys = Object.keys(
-      facilityTypeToKeyMap
-    ) as MinimalRecordType['type'][]
-    return facilityTypeKeys.map((type) => ({
-      id: getKeyByFacilityType(type),
-      type,
-    }))
-  }, [])
 
   return (
     <fieldset
@@ -132,25 +104,6 @@ function TextSearch({
           <Check className="scale-90 -mt-1" />
         </button>
       </div>
-      {checkboxes.map(({ id, type }) => (
-        <Checkbox
-          key={id}
-          id={id}
-          disabled={disabled}
-          onChange={(evt) => {
-            onChange({
-              text,
-              categories: {
-                ...categories,
-                [id]: evt.target.checked,
-              },
-            })
-          }}
-          checked={!!categories[id]}
-        >
-          <FacilityType type={type} />
-        </Checkbox>
-      ))}
     </fieldset>
   )
 }

--- a/src/components/TypeCheckboxesFilter.tsx
+++ b/src/components/TypeCheckboxesFilter.tsx
@@ -1,0 +1,69 @@
+import {
+  facilityTypeToKeyMap,
+  getKeyByFacilityType,
+} from '@lib/facilityTypeUtil'
+import { MinimalRecordType } from '@lib/mapRecordToMinimum'
+import React, { useMemo } from 'react'
+import Checkbox from './Checkbox'
+import FacilityType from './FacilityType'
+
+type CategoriesType = Partial<{
+  categorySelfHelp: boolean
+  categoryAdvising: boolean
+  categoryClinics: boolean
+  categoryOnlineOffers: boolean
+  categoryDistrictOfficeHelp: boolean
+}>
+
+export interface StateType {
+  text: string
+  categories: CategoriesType
+}
+
+interface TypeCheckboxesFilterProps extends StateType {
+  onChange: (state: Partial<StateType>) => void
+  disabled?: boolean
+}
+
+function TypeCheckboxesFilter({
+  onChange,
+  disabled,
+  text,
+  categories,
+}: TypeCheckboxesFilterProps): JSX.Element {
+  const checkboxes = useMemo(() => {
+    const facilityTypeKeys = Object.keys(
+      facilityTypeToKeyMap
+    ) as MinimalRecordType['type'][]
+    return facilityTypeKeys.map((type) => ({
+      id: getKeyByFacilityType(type),
+      type,
+    }))
+  }, [])
+
+  return (
+    <div>
+      {checkboxes.map(({ id, type }) => (
+        <Checkbox
+          key={id}
+          id={id}
+          disabled={disabled}
+          onChange={(evt) => {
+            onChange({
+              text,
+              categories: {
+                ...categories,
+                [id]: evt.target.checked,
+              },
+            })
+          }}
+          checked={!!categories[id]}
+        >
+          <FacilityType type={type} />
+        </Checkbox>
+      ))}
+    </div>
+  )
+}
+
+export default TypeCheckboxesFilter

--- a/src/lib/TextsContext.tsx
+++ b/src/lib/TextsContext.tsx
@@ -129,6 +129,7 @@ const defaultValue = {
   optionalFurtherSearchIntroText: '',
   filtersButtonLoading: '',
   websiteLabel: '',
+  offerTypesIntroText: '',
 }
 
 export type TextsMapType = typeof defaultValue


### PR DESCRIPTION
This PR flips the oder of presentation of the checkboxes and the text search in the filter list.

![image](https://github.com/technologiestiftung/hilf-mir.berlin/assets/2759340/d903ceec-6336-4b9a-894b-b34dc72fee40)
