### PR TITLE
refactor(LegalFooter): All offers links resets the filter

### DIFF
--- a/src/components/LegalFooter.tsx
+++ b/src/components/LegalFooter.tsx
@@ -3,10 +3,12 @@ import { FC } from 'react'
 import Link from 'next/link'
 import classNames from '@lib/classNames'
 import { useRouter } from 'next/router'
+import { useUrlState } from '@lib/UrlStateContext'
 
 export const LegalFooter: FC = () => {
   const texts = useTexts()
   const { query } = useRouter()
+  const [, , resetUrlState] = useUrlState()
 
   return (
     <>
@@ -29,10 +31,8 @@ export const LegalFooter: FC = () => {
             )}
           >
             <Link
-              href={{
-                pathname: '/map',
-                query,
-              }}
+              onClick={() => resetUrlState()}
+              href={{ pathname: '/map', query: {} }}
               className={classNames(
                 `underline transition-colors hover:text-primary`,
                 `focus:outline-none focus:ring-2 focus:ring-primary`,

--- a/src/components/LegalFooter.tsx
+++ b/src/components/LegalFooter.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import Link from 'next/link'
 import classNames from '@lib/classNames'
 import { useRouter } from 'next/router'
-import { useUrlState } from '@lib/UrlStateContext'
+import { allOffersStateDefault, useUrlState } from '@lib/UrlStateContext'
 
 export const LegalFooter: FC = () => {
   const texts = useTexts()
@@ -32,7 +32,12 @@ export const LegalFooter: FC = () => {
           >
             <Link
               onClick={() => resetUrlState()}
-              href={{ pathname: '/map', query: {} }}
+              href={{
+                pathname: '/map',
+                query: {
+                  qCategories: allOffersStateDefault.qCategories?.join(','),
+                },
+              }}
               className={classNames(
                 `underline transition-colors hover:text-primary`,
                 `focus:outline-none focus:ring-2 focus:ring-primary`,

--- a/src/lib/UrlStateContext.tsx
+++ b/src/lib/UrlStateContext.tsx
@@ -28,6 +28,16 @@ const UrlStateContext = createContext<
 
 const Provider = UrlStateContext.Provider
 
+export const allOffersStateDefault: PageQueryType = {
+  qCategories: stateSearchCategoriesToUrlSearchCategories({
+    categorySelfHelp: true,
+    categoryAdvising: true,
+    categoryClinics: true,
+    categoryDistrictOfficeHelp: true,
+    categoryOnlineOffers: true,
+  }),
+}
+
 export const useUrlState = (): [
   PageQueryType,
   SetUrlStateHandlerType,
@@ -92,9 +102,9 @@ export const UrlStateProvider: FC = ({ children }) => {
     [query.id, pathname, state, updateReactUrlState]
   )
 
-  const resetUrlState = useCallback(() => {
-    updateStateWindowLocation(pathname, {})
-    updateReactUrlState({})
+  const resetUrlStateToAll = useCallback(() => {
+    updateStateWindowLocation(pathname, allOffersStateDefault)
+    updateReactUrlState(allOffersStateDefault)
   }, [pathname, updateReactUrlState])
 
   // UPDATE REACT STATE ON NEXTJS ROUTER QUERY CHANGE
@@ -125,7 +135,7 @@ export const UrlStateProvider: FC = ({ children }) => {
   }, [query.id, pathname])
 
   return (
-    <Provider value={[state, updateUrlState, resetUrlState]}>
+    <Provider value={[state, updateUrlState, resetUrlStateToAll]}>
       {children}
     </Provider>
   )

--- a/src/lib/UrlStateContext.tsx
+++ b/src/lib/UrlStateContext.tsx
@@ -20,16 +20,24 @@ type ParsedSearchTermCategoriesType = {
 }
 
 type SetUrlStateHandlerType = (newState: PageQueryType) => void
+type ResetUrlStateHandlerType = () => void
 
-const UrlStateContext = createContext<[PageQueryType, SetUrlStateHandlerType]>([
-  {},
-  () => undefined,
-])
+const UrlStateContext = createContext<
+  [PageQueryType, SetUrlStateHandlerType, ResetUrlStateHandlerType]
+>([{}, () => undefined, () => undefined])
 
 const Provider = UrlStateContext.Provider
 
-export const useUrlState = (): [PageQueryType, SetUrlStateHandlerType] =>
-  useContext(UrlStateContext) as [PageQueryType, SetUrlStateHandlerType]
+export const useUrlState = (): [
+  PageQueryType,
+  SetUrlStateHandlerType,
+  ResetUrlStateHandlerType
+] =>
+  useContext(UrlStateContext) as [
+    PageQueryType,
+    SetUrlStateHandlerType,
+    ResetUrlStateHandlerType
+  ]
 
 export const UrlStateProvider: FC = ({ children }) => {
   const { query, pathname } = useRouter()
@@ -84,6 +92,11 @@ export const UrlStateProvider: FC = ({ children }) => {
     [query.id, pathname, state, updateReactUrlState]
   )
 
+  const resetUrlState = useCallback(() => {
+    updateStateWindowLocation(pathname, {})
+    updateReactUrlState({})
+  }, [pathname, updateReactUrlState])
+
   // UPDATE REACT STATE ON NEXTJS ROUTER QUERY CHANGE
   useEffect(
     () => updateReactUrlState(mappedQuery),
@@ -111,7 +124,11 @@ export const UrlStateProvider: FC = ({ children }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query.id, pathname])
 
-  return <Provider value={[state, updateUrlState]}>{children}</Provider>
+  return (
+    <Provider value={[state, updateUrlState, resetUrlState]}>
+      {children}
+    </Provider>
+  )
 }
 
 export function urlSearchCategoriesToStateSearchCategories(


### PR DESCRIPTION
This PR ensures that the footer link saying "All offers" does reset all filters to the default and ignores the currently applied filters.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205538506214403